### PR TITLE
added endpoint for finding eligible nam address + separated checkDona…

### DIFF
--- a/pages/api/calculate.js
+++ b/pages/api/calculate.js
@@ -34,10 +34,7 @@ export default async function handler(req, res) {
       const result = await pool.query(query, [startDate, endDate]);
       const totalSum = parseFloat(result.rows[0].total_sum);
       
-      // Cap the final sum at 27 ETH
-      const finalSum = totalSum > 27 ? 27 : totalSum;
-      
-      res.status(200).json({ totalSum: finalSum });
+      res.status(200).json({ totalSum: totalSum });
     } catch (error) {
       console.error('Error calculating sum:', error);
       res.status(500).json({ error: 'Failed to calculate total' });

--- a/pages/api/findNamAddress.js
+++ b/pages/api/findNamAddress.js
@@ -1,0 +1,46 @@
+import { pool } from '@/lib/db';
+
+dotenv.config();
+const endDate = process.env.SCANNING_END_DATE;
+
+/// This api endpoint finds the corresponding nam address for a given eth address
+export default async function handler(req, res) {
+    if (req.method !== 'GET') {
+        return res.status(405).json({ message: `Method ${req.method} Not Allowed` });
+    }
+    
+    try {
+        const { ethAddress } = req.query;
+    
+        if (!ethAddress) {
+            return res.status(400).json({ error: 'Missing required parameter: ethAddress' });
+        }
+    
+        const query = `
+            SELECT namada_key, timestamp
+            FROM donations 
+            WHERE from_address = $1
+            AND timestamp <= $2
+            ORDER BY timestamp DESC
+            LIMIT 1
+        `;
+    
+        const result = await pool.query(query, [
+            ethAddress.toLowerCase(),
+            endDate || 'infinity'
+        ]);
+        
+        if (result.rows.length === 0) {
+            return res.status(404).json({ error: 'No matching address found' });
+        }
+    
+        res.status(200).json({ 
+            namadaKey: result.rows[0].namada_key,
+            timestamp: result.rows[0].timestamp
+        });
+    
+    } catch (error) {
+        console.error('Error finding NAM address:', error);
+        res.status(500).json({ error: 'Failed to find NAM address' });
+    }
+}


### PR DESCRIPTION
Two changes:

1. findNamAddress endpoint that finds the correct eligible nam address from the eth_address as defined (latest donation as long as it is before the end date of the campaign)
2. Split checkDonation endpoint to not require a nam address. Can only pass eth address if want to